### PR TITLE
Use printJsonDecodeError instead of show for DecodeError

### DIFF
--- a/src/Flame/Application/PreMount.purs
+++ b/src/Flame/Application/PreMount.purs
@@ -2,6 +2,7 @@ module Flame.Application.PreMount where
 
 import Control.Monad.Except as CME
 import Data.Argonaut.Core as DAC
+import Data.Argonaut.Decode.Error as DADEE
 import Data.Argonaut.Decode.Generic.Rep (class DecodeRep)
 import Data.Argonaut.Decode.Generic.Rep as DADEGR
 import Data.Argonaut.Encode.Generic.Rep (class EncodeRep)
@@ -9,8 +10,8 @@ import Data.Argonaut.Encode.Generic.Rep as DAEGR
 import Data.Argonaut.Parser as DAP
 import Data.Array ((:))
 import Data.Array as DA
+import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
-import Data.Either as DE
 import Data.Generic.Rep (class Generic)
 import Data.Maybe (Maybe(..))
 import Data.Maybe as DM
@@ -58,7 +59,7 @@ serializedState selector = do
                 Nothing -> EE.throw $ "Error resuming application mount: serialized state not found!"
         where   decoding contents = do
                         json <- DAP.jsonParser contents
-                        DE.either (Left <<< show) Right $ DADEGR.genericDecodeJson json
+                        lmap DADEE.printJsonDecodeError (DADEGR.genericDecodeJson json)
 
 preMount :: forall model m message. Generic model m => EncodeRep m => QuerySelector -> PreApplication model message -> Effect String
 preMount (QuerySelector selector) application = do


### PR DESCRIPTION
Just a little edit on a Flame.Application.PreMount.serializedState, as it's more faithful to older behaviour.

Seems we've syncronized somehow, I've tried doing same thing today, had to bump argonaut version and also tried creating Spago configuration (about that, #21). 