### PR TITLE
Set 'autocomplete' attribute type to String

### DIFF
--- a/src/Flame/HTML/Attribute/Internal.purs
+++ b/src/Flame/HTML/Attribute/Internal.purs
@@ -745,8 +745,8 @@ version = createAttribute "version" <<< show
 numOctaves :: ToIntAttribute
 numOctaves = createAttribute "numOctaves" <<< show
 
-autocomplete :: ToBooleanAttribute
-autocomplete = createProperty "autocomplete" <<< booleanToFalsyString
+autocomplete :: ToStringAttribute
+autocomplete = createProperty "autocomplete"
 
 autofocus :: ToBooleanAttribute
 autofocus = createProperty "autofocus" <<< booleanToFalsyString

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -181,7 +181,7 @@ main =
                                                         HE.br,
                                                         HE.text "Test",
                                                         HE.button (HA.createAttribute "my-attribute" "myValue") "+",
-                                                        HE.hr' [HA.autocomplete false, HA.style { border: "200px solid blue"}] ,
+                                                        HE.hr' [HA.autocomplete "off", HA.style { border: "200px solid blue"}] ,
                                                         HE.div_ $ HE.div_ [
                                                                 HE.span_ [ HE.a [HA.autofocus true] "here" ]
                                                         ]
@@ -189,7 +189,7 @@ main =
                                         ]
                                 ]
                                 html' <- liftEffect $ FRS.render html
-                                TUA.equal """<html lang="en"><head disabled="true"><title>title</title></head><body id="content"><main><button style="display:block;width:20px">-</button><br>Test<button my-attribute="myValue">+</button><hr style="border:200px solid blue"><div><div><span><a autofocus="true">here</a></span></div></div></main></body></html>""" html'
+                                TUA.equal """<html lang="en"><head disabled="true"><title>title</title></head><body id="content"><main><button style="display:block;width:20px">-</button><br>Test<button my-attribute="myValue">+</button><hr autocomplete="off" style="border:200px solid blue"><div><div><span><a autofocus="true">here</a></span></div></div></main></body></html>""" html'
 
                         test "events" do
                                 let html = HE.a [HA.onClick unit, HA.onInput (const unit)] [HE.text "TEST"]


### PR DESCRIPTION
Also, patches the related test case (as `autocomplete` seems having no explicit default value).
Fixes #27.