### PR TITLE
Add style merging based on snabbdom style module

### DIFF
--- a/src/Flame/HTML/Attribute/Internal.purs
+++ b/src/Flame/HTML/Attribute/Internal.purs
@@ -51,10 +51,7 @@ class' :: forall a b. ToClassList b => b -> NodeData a
 class' = createAttribute "class" <<< caseify <<< to
 
 style :: forall a r. Homogeneous r String => { | r } -> NodeData a
-style record = Property "style" <<< DS.joinWith ";" <<< DA.zipWith zipper (FO.keys object) $ FO.values object
-        where   object = FO.fromHomogeneous record
-
-                zipper name' value' = caseify name' <> ":" <> value'
+style record = StyleList $ FO.fromHomogeneous record
 
 -- | Transforms its input into a proper html attribute/tag name, i.e. lower case and hyphenated
 caseify :: String -> String

--- a/src/Flame/Renderer/Renderer.js
+++ b/src/Flame/Renderer/Renderer.js
@@ -4,6 +4,7 @@ var patch = require('snabbdom').init([
 	require('snabbdom/modules/props').default,
 	require('snabbdom/modules/attributes').default,
 	require('snabbdom/modules/eventlisteners').default,
+	require('snabbdom/modules/style').default,
 ]);
 var h = require('snabbdom/h').default;
 var toVNode = require('snabbdom/tovnode').default;

--- a/src/Flame/Types.purs
+++ b/src/Flame/Types.purs
@@ -23,6 +23,7 @@ type VNodeData = {
         -- we need attrs mainly for svg
         attrs :: Object String,
         props :: Object String,
+        style :: Object String,
         key :: Nullable String,
         on :: VNodeEvents,
         hook :: Object Foreign
@@ -88,6 +89,7 @@ data NodeData message =
         Attribute String String |
         Key String |
         Property String String |
+        StyleList (Object String) |
         Event String message |
         RawEvent String (Event -> Effect (Maybe message)) |
         Hook String Foreign

--- a/test/Main.js
+++ b/test/Main.js
@@ -4,6 +4,9 @@ const enviroment = (new jsdom.JSDOM('', { runScripts: "outside-only" }));
 global.window = enviroment.window;
 global.document	= enviroment.window.document;
 
+// a dirty hack to make snabbdom style module import properly
+window.requestAnimationFrame = setTimeout;
+
 exports.unsafeCreateEnviroment = function () {
 	document.body.innerHTML = '<div id=mount-point></div>';
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -95,11 +95,20 @@ main =
                         test "inline style" do
                                 let html = HE.a (HA.style { mystyle: "test" }) [HE.text "TEST"]
                                 html' <- liftEffect $ FRS.render html
-                                TUA.equal """<a style="mystyle:test">TEST</a>""" html'
+                                TUA.equal """<a style="mystyle: test">TEST</a>""" html'
 
                                 let html2 = HE.a [HA.style { width: "23px", display: "none" }] [HE.text "TEST"]
                                 html2' <- liftEffect $ FRS.render html2
-                                TUA.equal """<a style="width:23px;display:none">TEST</a>""" html2'
+                                TUA.equal """<a style="width: 23px; display: none">TEST</a>""" html2'
+
+                        test "style merging" do
+                                let html = HE.a [ HA.style { mystyle: "test", mylife: "good" }, HA.style { mystyle: "check" } ] [HE.text "TEST"]
+                                html' <- liftEffect $ FRS.render html
+                                TUA.equal """<a style="mystyle: check; mylife: good">TEST</a>""" html'
+
+                                let html2 = HE.a [HA.style { width: "23px", display: "none" }, HA.style { height: "10px" } ] [HE.text "TEST"]
+                                html2' <- liftEffect $ FRS.render html2
+                                TUA.equal """<a style="width: 23px; display: none; height: 10px">TEST</a>""" html2'
 
                         test "style/class name case" do
                                 html <- liftEffect <<< FRS.render $ HE.createElement' "element" $ HA.class' "superClass"
@@ -115,7 +124,7 @@ main =
                                 TUA.equal """<element class="superclass"></element>""" html4
 
                                 html5 <- liftEffect <<< FRS.render $ HE.createElement' "element" $ HA.style { borderBox : "23", s : "34", borderLeftTopRadius : "20px"}
-                                TUA.equal """<element style="border-box:23;s:34;border-left-top-radius:20px"></element>""" html5
+                                TUA.equal """<element style="border-box: 23; s: 34; border-left-top-radius: 20px"></element>""" html5
 
                                 html6 <- liftEffect <<< FRS.render $ HE.createElement' "element" $ HA.class' { borderBox : true, s : false, borderLeftTopRadius : true}
                                 TUA.equal """<element class="border-box border-left-top-radius"></element>""" html6
@@ -174,7 +183,7 @@ main =
                                         ]
                                 ]
                                 html' <- liftEffect $ FRS.render html
-                                TUA.equal """<html lang="en"><head><title>title</title></head><body id="content"><main><button style="display:block;width:20px">-</button><br>Test<button my-attribute="myValue">+</button><hr style="border:200px solid blue"><div><div><span><a>here</a></span></div></div></main></body></html>""" html'
+                                TUA.equal """<html lang="en"><head><title>title</title></head><body id="content"><main><button style="display: block; width: 20px">-</button><br>Test<button my-attribute="myValue">+</button><hr style="border: 200px solid blue"><div><div><span><a>here</a></span></div></div></main></body></html>""" html'
 
                         test "nested elements with properties and attributes" do
                                 let html = HE.html [HA.lang "en"] [
@@ -193,7 +202,7 @@ main =
                                         ]
                                 ]
                                 html' <- liftEffect $ FRS.render html
-                                TUA.equal """<html lang="en"><head disabled="true"><title>title</title></head><body id="content"><main><button style="display:block;width:20px">-</button><br>Test<button my-attribute="myValue">+</button><hr autocomplete="off" style="border:200px solid blue"><div><div><span><a autofocus="true">here</a></span></div></div></main></body></html>""" html'
+                                TUA.equal """<html lang="en"><head disabled="true"><title>title</title></head><body id="content"><main><button style="display: block; width: 20px">-</button><br>Test<button my-attribute="myValue">+</button><hr autocomplete="off" style="border: 200px solid blue"><div><div><span><a autofocus="true">here</a></span></div></div></main></body></html>""" html'
 
                         test "events" do
                                 let html = HE.a [HA.onClick unit, HA.onInput (const unit)] [HE.text "TEST"]


### PR DESCRIPTION
Doesn't break API, but changes the way Flame treats multiple `style` properties. Now it merges them akin Hedwig and Elm.

`styleAttr` is completely overridden by `style` lists.
Old style overlap behavior is attainable through `unset` CSS keyword.

Resolves #32, which contains rationale for this change.