### PR TITLE
docs(examples): add try purescript links table

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,16 @@ Build all examples with
 npm run build-examples
 ```
 or go to each individual folder to build them separately.
+
+## Try on [Try Purescript](try.purescript.org)
+You can also load each example from the following urls:
+|  Example        |  Link                                                                                                               |
+| ---------       | ---------------------------------------------------------------------------------------------------------           |
+| Affjax          | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/Affjax/Affjax.purs)               |
+| Counter         | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/Counter/Counter.purs)             |
+| Dice            | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/Dice/Dice.purs)                   |
+| EffectfulAffjax | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/EffectfulAffjax/Affjax.purs)      |
+| EffectfulDice   | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/EffectfulDice/Dice.purs)          |
+| SpecialElements | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/SpecialElements/Special.purs)     |
+| Subscriptions   | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/Subscriptions/Subscriptions.purs) |
+| Todo            | [Link](https://try.purescript.org?github=/easafe/purescript-flame/master/examples/Todo/Todo.purs)                   |


### PR DESCRIPTION
in addressing #82, you can use the github query param feature on [try.purescript.org](try.purescript.org) to load the code with that service and get a running example to toy with.

noticed this when perusing and thought it might make for a hassle free way to see the simpler examples.

only missing examples are counters (which has a noeffects counter import) and server side rendering (for obvious reasons)